### PR TITLE
130-136-fix-duplicate-detection in Name and JobTitle

### DIFF
--- a/src/main/java/seedu/address/model/applicant/Name.java
+++ b/src/main/java/seedu/address/model/applicant/Name.java
@@ -47,9 +47,21 @@ public class Name {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof seedu.address.model.applicant.Name // instanceof handles nulls
-                && fullName.equals(((seedu.address.model.applicant.Name) other).fullName)); // state check
+        //short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        //handles null
+        if (!(other instanceof Name)) {
+            return false;
+        }
+
+        // casing difference and extra spaces don't differentiate job titles
+        String modifiedOtherTitle = other.toString().replaceAll("\\s{2,}", " ").strip().toUpperCase();
+        String modifiedTitle = this.fullName.replaceAll("\\s{2,}", " ").strip().toUpperCase();
+
+        return modifiedTitle.equals(modifiedOtherTitle);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/listing/JobTitle.java
+++ b/src/main/java/seedu/address/model/listing/JobTitle.java
@@ -76,9 +76,21 @@ public class JobTitle {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof JobTitle // instanceof handles nulls
-                && fullTitle.equals(((JobTitle) other).fullTitle)); // state check
+        //short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        //handles null
+        if (!(other instanceof JobTitle)) {
+            return false;
+        }
+
+        // casing difference and extra spaces don't differentiate job titles
+        String modifiedOtherTitle = other.toString().replaceAll("\\s{2,}", " ").strip().toUpperCase();
+        String modifiedTitle = this.fullTitle.replaceAll("\\s{2,}", " ").strip().toUpperCase();
+
+        return modifiedTitle.equals(modifiedOtherTitle);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/listing/Listing.java
+++ b/src/main/java/seedu/address/model/listing/Listing.java
@@ -46,7 +46,9 @@ public class Listing {
         return applicants;
     }
 
-    public ArrayList<Platform> getPlatforms() { return platforms; }
+    public ArrayList<Platform> getPlatforms() {
+        return platforms;
+    }
 
     public int getPlatformCount() {
         return platforms.size();

--- a/src/test/java/seedu/address/model/applicant/ApplicantTest.java
+++ b/src/test/java/seedu/address/model/applicant/ApplicantTest.java
@@ -21,14 +21,14 @@ public class ApplicantTest {
         // null -> returns false
         assertFalse(BENEDICT.isSameApplicant(null));
 
-        // name differs in case -> false
+        // name differs in case -> true
         Applicant editedChris = new ApplicantBuilder(CHRIS).withName(VALID_APPLICANT_NAME_CHRIS.toLowerCase()).build();
-        assertFalse(CHRIS.isSameApplicant(editedChris));
+        assertTrue(CHRIS.isSameApplicant(editedChris));
 
         // name has trailing spaces -> true
         String nameWithTrailingSpaces = VALID_APPLICANT_NAME_BENEDICT + " ";
-        Applicant editedBenedict = new ApplicantBuilder(BENEDICT).withName(nameWithTrailingSpaces).build();
-        assertTrue(BENEDICT.isSameApplicant(editedBenedict));
+        Applicant editedBenedictTrailing = new ApplicantBuilder(BENEDICT).withName(nameWithTrailingSpaces).build();
+        assertTrue(BENEDICT.isSameApplicant(editedBenedictTrailing));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/listing/ListingTest.java
+++ b/src/test/java/seedu/address/model/listing/ListingTest.java
@@ -38,11 +38,11 @@ public class ListingTest {
         editedChickenRiceUncle = new ListingBuilder(CHICKEN_RICE_UNCLE).withTitle(VALID_TITLE).build();
         assertFalse(CHICKEN_RICE_UNCLE.isSameListing(editedChickenRiceUncle));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Listing editedToiletCleaner = new ListingBuilder(TOILET_CLEANER)
                 .withTitle(TOILET_CLEANER.getTitle().toString().toLowerCase())
                 .build();
-        assertFalse(TOILET_CLEANER.isSameListing(editedToiletCleaner));
+        assertTrue(TOILET_CLEANER.isSameListing(editedToiletCleaner));
 
     }
 


### PR DESCRIPTION
## Which ticket does this address

- closes #130 
- closes #136 

## What problems does this solve

- `JobTitle` and `Name` with different case and extra spaces were not flagged as duplicates.

## Solution/Changes

- Changed the .equal() method to both classes to detect said duplicates.

## Checklist

- [x] All tests pass locally and on CI
